### PR TITLE
Avoid implementation-defined signedness of MV_8

### DIFF
--- a/common/mvTypes.h
+++ b/common/mvTypes.h
@@ -121,7 +121,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef MV_ASMLANGUAGE
 /* typedefs */
 
-typedef char MV_8;
+typedef signed char MV_8;
 typedef unsigned char MV_U8;
 
 typedef int MV_32;


### PR DESCRIPTION
It's up to the compiler whether plain `char` is `signed` or `unsigned`.